### PR TITLE
Plone4.3 and lxml compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -364,6 +364,10 @@ History
 0.2dev
 ------
 
+* Plone 4.3 compatibility
+* lxml compatibility (imsvdex dropped elementtree in favour of lxml)
+  [ale-rt]
+
 * A bunch of refactoring in order to add a new vocab type: TreeVocabulary.
   As the name suggests, treevocabulary supports
   ``zope.schema.interfaces.ITreeVocabulary``. It has better i18n-support using

--- a/README.rst
+++ b/README.rst
@@ -366,6 +366,7 @@ History
 
 * Plone 4.3 compatibility
 * lxml compatibility (imsvdex dropped elementtree in favour of lxml)
+* entry point for z3c.autoinclude
   [ale-rt]
 
 * A bunch of refactoring in order to add a new vocab type: TreeVocabulary.

--- a/setup.py
+++ b/setup.py
@@ -43,4 +43,10 @@ setup(
             'interlude',
         ]
     },
+    entry_points="""
+        # -*- Entry points: -*-
+
+       [z3c.autoinclude.plugin]
+       target = plone
+    """,
 )


### PR DESCRIPTION
Without this patch users will always be in the situation filed under #1 because it will not be possible to get the Plone site language.

The original code was relying in zope.app.component.hooks import getSite, which is no longer there. 
The ImportError is not raised it is in  try/except.

The patch also makes theproduct work with imsvdex after it switched from elementree to lxml:

``` diff
[ale@padme ~]$svn diff -r252781 http://svn.plone.org/svn/collective/imsvdex/trunk/setup.py
Index: setup.py
===================================================================
--- setup.py    (revision 252781)
+++ setup.py    (revision 252856)
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import sys, os

-version = '2.0a1'
+version = '2.0.dev0'

 setup(name='imsvdex',
     version=version,
@@ -9,6 +9,7 @@
     long_description=open('README.txt').read() + "\n" +
                      open('CHANGES.txt').read(),
     classifiers=[
+          'Programming Language :: Python :: 2.7',
           # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
           'Development Status :: 5 - Production/Stable',
           'Intended Audience :: Developers',
@@ -25,8 +26,5 @@
     include_package_data=True,
     test_suite='imsvdex.tests',
     zip_safe=False,
-    install_requires=[
-        'elementtree>=1.2.6',
-        'elementtreewriter>=1.0',
-    ],
+    install_requires=['lxml',],
 )
```
