### PR TITLE
switch to getroot

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 0.3 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Newer lxml doesn't allow accessing ``_root`` anymore.
+  This switches to ``getroot()``.
+  [pilz]
 
 
 0.2.1 (2015-06-22)

--- a/src/collective/vdexvocabulary/treevocabulary.py
+++ b/src/collective/vdexvocabulary/treevocabulary.py
@@ -85,7 +85,7 @@ class VdexTreeVocabulary(TreeVocabulary):
         message_factory = MessageFactory(translationdomain.domain)
 
         # build TreeVocabulary with children
-        rootelement = self.vdex.tree._root
+        rootelement = self.vdex.tree.getroot()
         self._createTermTree(rootelement, self._terms, message_factory)
         self._populateIndexes(self._terms)
 


### PR DESCRIPTION
Newer lxml doesn't allow accessing _root anymore. This switches to getroot()
